### PR TITLE
Removed config that disables shared-folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,7 +73,6 @@ Vagrant.configure(2) do |config|
       node.vm.box = 'centos/7'
       node.vm.hostname = "node-#{i}"
       node.vm.network "private_network", ip: "192.168.44.#{i + 10}"
-      node.vm.synced_folder ".", "/home/vagrant/sync", disabled: true
     end
   end
 end


### PR DESCRIPTION
The shared-folder feature was disabled because in the previous versions
of CentOS vagrant image rsync was not present and each vagrant up was
trying to install rsync.

In the latest version of CentOS vagrant basebox rsync is preinstalled.
